### PR TITLE
Add an option to allow ANSI colors inside table data

### DIFF
--- a/lib/Text/Table/Tiny.pm
+++ b/lib/Text/Table/Tiny.pm
@@ -63,7 +63,8 @@ sub generate_table {
                 my $row_len   = $widths->[$y];
                 my $diff      = $row_len - $real_len;
                 my $spacer    = " " x $diff;
-                $row->[$y]   .= $spacer;
+                my $reset     = "\e[0m";
+                $row->[$y]   .= $reset . $spacer;
             }
         }
 


### PR DESCRIPTION
Text::Table::Tiny uses sprintf for column alignment. Text that is
colored or highlighted with ANSI color breaks alignment. When you
length($str) an ANSI string you get all the unprintable ANSI chars
also which causes the width to be way off.

This works by stripping all the ANSI color when calculating the
column widths, and also padding the output with spaces.