### PR TITLE
Add option to skip left and right borders

### DIFF
--- a/lib/Text/Table/Tiny.pm
+++ b/lib/Text/Table/Tiny.pm
@@ -1,6 +1,6 @@
 package Text::Table::Tiny;
 
-use 5.010;
+use 5.008;
 use strict;
 use warnings;
 use utf8;
@@ -49,9 +49,9 @@ sub generate_table
     my @rows    = @$rows;
     my @widths  = _calculate_widths($rows);
 
-    $param{style}  //= 'classic';
+    $param{style} = 'classic' if not defined $param{style};
 
-    $param{indent} //= '';
+    $param{indent} = '' if not defined $param{indent};
     $param{indent} = ' ' x $param{indent} if $param{indent} =~ /^[0-9]+$/;
 
     my $style   = $param{style};
@@ -151,7 +151,7 @@ sub _text_row
     my $text = $param->{indent}.$char->{VR};
 
     for (my $i = 0; $i < @$widths; $i++) {
-        $text .= _format_column($columns[$i] // '', $widths->[$i], $align->[$i] // 'l', $param, $char);
+        $text .= _format_column($columns[$i], $widths->[$i], $align->[$i], $param, $char);
         $text .= $char->{VR};
     }
     $text .= "\n";
@@ -162,6 +162,8 @@ sub _text_row
 sub _format_column
 {
     my ($text, $width, $align, $param, $char) = @_;
+    $text = '' if not defined $text;
+    $align = 'l' if not defined $align;
     my $pad = $param->{compact} ? '' : ' ';
 
     if ($align eq 'r' || $align eq 'right') {


### PR DESCRIPTION
Similar to `top_and_tail`, this adds an option to remove the left and right borders. It works with all three styles.

Example:
```perl
use Text::Table::Tiny 1.02 qw/ generate_table /;

my $rows = [
  [qw/ Pokemon     Type     Count /],
  [qw/ Abra        Psychic      5 /],
  [qw/ Ekans       Poison     123 /],
  [qw/ Feraligatr  Water     5678 /],
];

print generate_table(rows => $rows, header_row => 1, left_and_right => 1), "\n";
```

Will generate the following:
```
-----------+---------+------
Pokemon    | Type    | Count
-----------+---------+------
Abra       | Psychic | 5
Ekans      | Poison  | 123
Feraligatr | Water   | 5678
-----------+---------+------
```

Or combined with `top_and_tail` (for which I introduced a shortcut `edges`):
```perl
print generate_table(rows => $rows, header_row => 1, top_and_tail => 1, left_and_right => 1), "\n";
print generate_table(rows => $rows, header_row => 1, edges => 1), "\n";
```

```
Pokemon    | Type    | Count
-----------+---------+------
Abra       | Psychic | 5
Ekans      | Poison  | 123
Feraligatr | Water   | 5678
```

Note that this is based on #15 for Perl 5.8 compatibility, the actual changes can be seen in https://github.com/neilb/Text-Table-Tiny/commit/d57779dc49fb1fd142bee11f6e7ae9ed5a598e88?w=1. If the other PR is not accepted, it's trivial to rebase it to `master` instead. Also I didn't add documentation and tests yet, happy to do that if there's interest in this enhancement.